### PR TITLE
Document PostgreSQL deployment steps

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,0 +1,7 @@
+{
+  "requires": {
+    "db": {
+      "kind": "postgres"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -13,11 +13,18 @@ This project demonstrates a simple [SAP Cloud Application Programming Model](htt
 2. Create configuration files in the project root:
    - **`pg-db-config.json`** – PostgreSQL connection details
    - **`settings.json`** – Credentials for fetching OData metadata
-3. Start in development mode
+3. Deploy the database schema (run once)
+   ```bash
+   npx cds deploy --model-only
+   ```
+   This creates the `cds_model` table and avoids errors like
+   "Didn't find deployed model for PostgreSQL" on first deployment.
+   Repeat `npx cds deploy` when the model changes.
+4. Start in development mode
    ```bash
    npm run watch
    ```
-4. Start in production
+5. Start in production
    ```bash
    npm start
    ```


### PR DESCRIPTION
## Summary
- configure CAP to use Postgres by default
- document how to deploy the database before running the service

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a43e61264832bab4528d2c32303a9